### PR TITLE
text view content offset 이슈 해결

### DIFF
--- a/Carte/CarteViewController.swift
+++ b/Carte/CarteViewController.swift
@@ -154,6 +154,7 @@ public class CarteDetailViewController: UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = UIColor.whiteColor()
         self.textView.frame = self.view.bounds
+        self.textView.contentOffset = CGPoint(x: 0, y: 0)
         self.view.addSubview(self.textView)
     }
 

--- a/Carte/CarteViewController.swift
+++ b/Carte/CarteViewController.swift
@@ -154,7 +154,7 @@ public class CarteDetailViewController: UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = UIColor.whiteColor()
         self.textView.frame = self.view.bounds
-        self.textView.contentOffset = CGPoint(x: 0, y: 0)
+        self.textView.contentOffset = .zero
         self.view.addSubview(self.textView)
     }
 


### PR DESCRIPTION
### kor.
- 상세 화면 내 Text view의 내용이 위로 밀려 보이던 현상을 발견했습니다.
  - _**ex**_ Demo 프로젝트 내 CarteViewController에서 `UITextView+Placeholder` row 선택시, text view 상단의 `The MIT License (MIT)` 부분이 Navigation bar에 가려져 보입니다.
- viewDidLoad: method 내에서 text view의 contentOffset을 0,0으로 변경했습니다.
### eng.
- I solved a problem that some characters in text view are hidden.
- So, I set the text view's `contentOffset` as 0,0 in the viewDidLoad: method.
