### PR TITLE
Support the situation when VC is pushed by UINavigationController, not adding Done button

### DIFF
--- a/Carte/CarteViewController.swift
+++ b/Carte/CarteViewController.swift
@@ -47,8 +47,14 @@ public class CarteViewController: UITableViewController {
     public override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         
-        if self.presentingViewController != nil && self.navigationItem.leftBarButtonItem == nil {
-            self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Done,
+        // pushed
+        if self.navigationController?.viewControllers.count > 1 {
+            self.navigationItem.leftBarButtonItem = nil
+        }
+        // presented
+        else if self.presentingViewController != nil && self.navigationItem.leftBarButtonItem == nil {
+            self.navigationItem.leftBarButtonItem = UIBarButtonItem(
+                barButtonSystemItem: .Done,
                 target: self,
                 action: "doneButtonDidTap"
             )

--- a/Carte/CarteViewController.swift
+++ b/Carte/CarteViewController.swift
@@ -45,6 +45,8 @@ public class CarteViewController: UITableViewController {
     }
 
     public override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+        
         if self.presentingViewController != nil && self.navigationItem.leftBarButtonItem == nil {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Done,
                 target: self,


### PR DESCRIPTION
1) I found a bug(maybe) when I use `viewController(:sender:)` to push `CarteViewController`.
It couldn't find a back button when in the left side of `UINavigationBar`. 
It removes the back button made by `UINavigationBar` so that I can't back to previous screen.
When I tap the done button, whole `UINavigationViewController` stack is dismissed.

I tried `self.navigationItem.backBarButtonItem` it also returned `nil`. 

I suggest this PR to avoid this situation. I can't use now this because of this situation.

If this Done button would be an option, it has more chance to be used by other programmers.

2) I added `super.viewWillAppear()`. As I know, this is basically recommended.
http://stackoverflow.com/questions/3348204/what-does-super-viewwillappear-do-and-when-is-it-required
