### PR TITLE
Disable showEnvVarsInLog when adding shell script build phase

### DIFF
--- a/Sources/Carte/carte.rb
+++ b/Sources/Carte/carte.rb
@@ -52,6 +52,7 @@ class ProjectIntegrator
     phase.initialize_defaults
     phase.name = name
     phase.shell_script = shell_script
+    phase.show_env_vars_in_log = '0'
     return phase
   end
 


### PR DESCRIPTION
There's a bug: `showEnvVarsInLog = 1;` appears after `pod install` and disappears when a new file is added.